### PR TITLE
Fix key handling for CTRL and CMD keys

### DIFF
--- a/src/main/store/runAgent.ts
+++ b/src/main/store/runAgent.ts
@@ -177,6 +177,8 @@ export const performAction = async (action: NextAction) => {
     case 'key':
       const keyMap = {
         Return: Key.Enter,
+        ctrl: Key.LeftControl,
+        cmd: Key.LeftSuper,
       };
       const keys = action.text.split('+').map((key) => {
         const mappedKey = keyMap[key as keyof typeof keyMap];
@@ -246,6 +248,12 @@ export const runAgent = async (
       if (!getState().running) {
         break;
       }
+
+      // Replace 'ctrl' with 'cmd' for Mac OS
+      if (process.platform === 'darwin' && action.type === 'key') {
+        action.text = action.text.replace('ctrl', 'cmd');
+      }
+
       performAction(action);
 
       await new Promise((resolve) => setTimeout(resolve, 500));


### PR DESCRIPTION
Fixes #12

Update `performAction` and `runAgent` functions to handle 'ctrl' and 'cmd' keys for Mac OS.

* **Key Mapping:**
  - Add 'ctrl' and 'cmd' keys to the `keyMap` in `performAction` function.
  - Map 'ctrl' to `Key.LeftControl` and 'cmd' to `Key.LeftSuper`.

* **Mac OS Specific Logic:**
  - Add logic in `runAgent` function to replace 'ctrl' with 'cmd' for Mac OS.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/corbt/agent.exe/issues/12?shareId=00ddd6af-87d6-46a4-b967-902c3b2d4061).